### PR TITLE
Add item: Suppr Zotero Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,9 @@ Back up the library → use Linter to normalize metadata → use ZoteroDuplicate
 - [zotero-chatgpt](https://github.com/kazgu/zotero-chatgpt)
   Lightweight add-on for summarization and translation via the ChatGPT API—good for occasional use.
 
+- [Suppr Zotero Plugin](https://github.com/WildDataX/suppr-zotero-plugin)
+  Adds the Suppr document translation workflow to Zotero, with one-click translation for PDFs and Office documents. Useful when you want AI-assisted bilingual reading while keeping the Zotero literature-management context.
+
 > Before using these add-ons, make sure you're comfortable with how the underlying services process your data. Do not send confidential manuscripts or sensitive data to third parties.
 
 ### Integration with other tools

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -255,6 +255,9 @@
 - [zotero-chatgpt](https://github.com/kazgu/zotero-chatgpt)
   通过 ChatGPT API 做总结与翻译的轻量插件，适合作为按需尝试的选件。
 
+- [Suppr Zotero Plugin](https://github.com/WildDataX/suppr-zotero-plugin)
+  将 Suppr 超能文献的文档翻译工作流接入 Zotero，支持对 PDF、Word、PowerPoint 等文档进行一键翻译，适合希望在 Zotero 文献管理场景中完成双语阅读与论文翻译的用户。
+
 > 使用这类插件前，请确认自己可以接受相应服务对数据的处理方式，不要把保密稿件与敏感数据直接发送给第三方服务。
 
 ### 与其他工具的集成


### PR DESCRIPTION
This PR adds Suppr Zotero Plugin to the AI / large-language-model integration section.\n\nSuppr Zotero Plugin connects Suppr's document translation workflow with Zotero, supporting one-click translation for PDFs and Office documents while keeping the literature-management context in Zotero.\n\nLinks:\n- Repository: https://github.com/WildDataX/suppr-zotero-plugin\n- Latest release: https://github.com/WildDataX/suppr-zotero-plugin/releases/latest\n- Landing page: https://suppr.wilddata.cn/landing/zotero\n\nI added both English and Chinese entries to keep the bilingual README files aligned.