### PR TITLE
Add Weavero

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ Community-maintained navigation to the Zotero 7 ecosystem. Focused on high-quali
 - [zotero-ocr](https://github.com/UB-Mannheim/zotero-ocr)
   Runs OCR on scanned PDFs to generate searchable text, with optional annotations or hOCR output.
 
+- [Weavero](https://github.com/mjthoraval/Weavero)
+  A Zotero plugin to make clickable links and filter your library.
+
 ### Metadata cleanup and de-duplication
 
 - [Linter for Zotero](https://github.com/northword/zotero-format-metadata)


### PR DESCRIPTION
Adds [Weavero](https://github.com/mjthoraval/Weavero) to the **Reading and note-taking enhancements** section.

Weavero is a Zotero 7+ plugin that turns URLs in annotation comments and notes into clickable links across the items tree, right item pane, reader sidebar, in-PDF popup, and notes. It also adds a filter pane (color/type/tag/author/collection, with include/exclude), related-item plumbing, a tabs-menu overhaul, and customizable items-tree columns.

- Repository: https://github.com/mjthoraval/Weavero
- Already indexed by `syt2/zotero-addons-scraper` (tags: `reader`, `interface`).
- Tested against Zotero 10.0-beta.

I'm the author. Happy to adjust placement, wording, or section if maintainers prefer.