### PR TITLE
Add item: Zotero Metadata Hunter

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Community-maintained navigation to the Zotero 7 ecosystem. Focused on high-quali
 ### Metadata cleanup and de-duplication
 
 - [Linter for Zotero](https://github.com/northword/zotero-format-metadata)
+- [Zotero Metadata Hunter](https://github.com/federicotorrielli/zotero-metadata-hunter)
+  Finds missing DOIs and abstracts, replaces preprints with their published versions, and enriches sparse records while keeping attachments and annotations intact.
 - [ZoteroDuplicatesMerger](https://github.com/frangoud/ZoteroDuplicatesMerger)
 - [Zoplicate](https://github.com/Polygon/zoplicate)
 - [Attachment Scanner](https://github.com/retorquere/zotero-attachment-scanner)

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -217,6 +217,8 @@
 ### 元数据清理与去重
 
 - [Linter for Zotero](https://github.com/northword/zotero-format-metadata)
+- [Zotero Metadata Hunter](https://github.com/federicotorrielli/zotero-metadata-hunter)
+  查找缺失的 DOI 和摘要，将预印本替换为已发表版本，并补全文献条目的稀疏元数据，同时保留附件和批注。
 - [ZoteroDuplicatesMerger](https://github.com/frangoud/ZoteroDuplicatesMerger)
 - [Zoplicate](https://github.com/Polygon/zoplicate)
 - [Attachment Scanner](https://github.com/retorquere/zotero-attachment-scanner)


### PR DESCRIPTION
- Add Zotero Metadata Hunter to the metadata cleanup and de-duplication section.
- Mirror the entry in the Chinese README so both language versions stay aligned.

Zotero Metadata Hunter helps Zotero 7 users find missing DOIs and abstracts, replace preprints with published versions, and enrich sparse records while keeping attachments and annotations intact.

