### PR TITLE
Add item: arxiv-marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ Community-maintained navigation to the Zotero 7 ecosystem. Focused on high-quali
 - [zotero-javascripts](https://github.com/redleafnew/zotero-javascripts)
   A collection of batch-processing scripts for advanced users, e.g., bulk-change title case, clear specific fields, or normalize language fields.
 
+- [zotero-marker](https://github.com/lelelelelelelelelelelelele/zotero_marker)
+  Resolves the real publication venue, CORE/CCF tier, and citation count of arXiv preprints (via Semantic Scholar + DBLP) and writes them back as proper Zotero metadata, so impact-factor / CCF / citation add-ons such as easyScholar and Citation Tally recognize them. Deterministic, with every change reviewed before writing.
+
 ### Web and online bibliographies
 
 - [Zotsite](https://github.com/plandes/zotsite)

--- a/README.md
+++ b/README.md
@@ -154,9 +154,6 @@ Community-maintained navigation to the Zotero 7 ecosystem. Focused on high-quali
 - [zotero-javascripts](https://github.com/redleafnew/zotero-javascripts)
   A collection of batch-processing scripts for advanced users, e.g., bulk-change title case, clear specific fields, or normalize language fields.
 
-- [zotero-marker](https://github.com/lelelelelelelelelelelelele/zotero_marker)
-  Resolves the real publication venue, CORE/CCF tier, and citation count of arXiv preprints (via Semantic Scholar + DBLP) and writes them back as proper Zotero metadata, so impact-factor / CCF / citation add-ons such as easyScholar and Citation Tally recognize them. Deterministic, with every change reviewed before writing.
-
 ### Web and online bibliographies
 
 - [Zotsite](https://github.com/plandes/zotsite)
@@ -243,6 +240,9 @@ Back up the library → use Linter to normalize metadata → use ZoteroDuplicate
 
 - [zotero-inspire](https://github.com/inspirehep/zotero-inspire)
   Deep integration with INSPIRE-HEP for high-energy physics and related fields; a common tool in that community.
+
+- [arxiv-marker](https://github.com/lelelelelelelelelelelelele/arxiv-marker)
+  Resolves the real publication venue, CORE/CCF tier, and citation count of arXiv preprints (Semantic Scholar, with a DBLP fallback for CS conferences) and writes them back as proper Zotero metadata, so evaluation add-ons such as Zotero-IF, Citation Tally, and Ethereal Style recognize them. Native Zotero 7/9 plugin; deterministic, with every change reviewed before writing.
 
 ### AI and large-language-model integration
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -241,6 +241,9 @@
 - [zotero-inspire](https://github.com/inspirehep/zotero-inspire)
   面向高能物理等领域，深度集成 INSPIRE-HEP, 是该社区的常见工具。
 
+- [arxiv-marker](https://github.com/lelelelelelelelelelelelele/arxiv-marker)
+  解析 arXiv 预印本的真实发表会议/期刊、CORE/CCF 等级与引用次数（Semantic Scholar，CS 会议用 DBLP 兜底），并写回为规范的 Zotero 元数据，让 Zotero-IF、Citation Tally、Ethereal Style 等评估类插件能识别它们。原生 Zotero 7/9 插件；确定性解析，写入前逐条预览确认。
+
 ### AI 与大模型集成
 
 - [Awesome GPT for Zotero](https://github.com/MuiseDestiny/zotero-gpt)


### PR DESCRIPTION
Author here — updating this PR after renaming the project (zotero-marker → arxiv-marker) and shipping a native Zotero 7/9 plugin.

**Why:** In CS/ML most papers hit arXiv first; Zotero imports them as `preprint`, which has no venue field — so evaluation add-ons (Zotero-IF, Citation Tally, Ethereal Style, easyScholar) can't show CCF/CORE tier, impact factor, or citation count for them, however cited.

**What it does:** keys on the arXiv id, resolves the real venue via Semantic Scholar (DBLP fallback for the many CS conferences with no Crossref DOI), converts `preprint` → `conferencePaper`/`journalArticle`, fills the venue fields, and writes the citation count to `Extra` — so those add-ons light up. Deterministic (no LLM guessing); every change is shown in a table for review before writing. I use it on my own library.

**Placement (updated):** it's now a native Zotero 7/9 add-on (v0.2.0 ships `arxiv-marker-0.2.0.xpi` + auto-update), so I moved the entry from *Programming interfaces and batch processing* to **Zotero add-ons (Zotero 7) → Evaluation and scholarly intelligence**, next to Zotero-IF / Citation Tally / zotero-inspire — it's the CS/ML counterpart to zotero-inspire. (A CLI / local web UI still exists for batch runs.) I've added the matching `README.zh-cn.md` entry too.

Repo (EN + 中文 docs): https://github.com/lelelelelelelelelelelelele/arxiv-marker
