### PR TITLE
Add item: Zotero-TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ Community-maintained navigation to the Zotero 7 ecosystem. Focused on high-quali
 - [zotero-ocr](https://github.com/UB-Mannheim/zotero-ocr)
   Runs OCR on scanned PDFs to generate searchable text, with optional annotations or hOCR output.
 
+- [Zotero-TTS](https://github.com/xujialiu/Zotero-TTS)
+  Enhances Zotero 10's built-in Read Aloud: more voices in its Local tier (Azure Speech, a local Kokoro server, any OpenAI-compatible server, your system's voices), word and sentence highlighting at once in your own colors, and keyboard shortcuts for speed and skipping. Requires Zotero 10.
+
 ### Metadata cleanup and de-duplication
 
 - [Linter for Zotero](https://github.com/northword/zotero-format-metadata)

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -214,6 +214,9 @@
 - [zotero-ocr](https://github.com/UB-Mannheim/zotero-ocr)
   为扫描版 PDF 执行 OCR, 生成可检索文本，并可同时生成注释或 hOCR 输出。
 
+- [Zotero-TTS](https://github.com/xujialiu/Zotero-TTS)
+  Zotero 10 内置朗读功能的增强插件：本地语音模式里更多语音（Azure Speech、本地 Kokoro 服务、任意 OpenAI 兼容服务、系统语音）、按你的颜色逐词与逐句同时高亮、语速与跳转快捷键。需要 Zotero 10。
+
 ### 元数据清理与去重
 
 - [Linter for Zotero](https://github.com/northword/zotero-format-metadata)


### PR DESCRIPTION
Adds Zotero-TTS to "Reading and note-taking enhancements", in README.md and README.zh-cn.md.

It enhances Zotero 10's built-in Read Aloud rather than replacing it: more voices in its Local tier (Azure Speech, a local Kokoro server, any OpenAI-compatible server, the system's voices), word and sentence highlighting at once in your own colors, and keyboard shortcuts for speed and skipping. Docs and setup tutorials are in the README: https://github.com/xujialiu/Zotero-TTS

I'm the author. It needs Zotero 10, which the entry says, since the section still names Zotero 7.
