### PR TITLE
Add item: DevScholar

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ Back up the library → use Linter to normalize metadata → use ZoteroDuplicate
 - [zotero-roam](https://github.com/alixlahuec/zotero-roam)
   Connector between Roam Research and Zotero, automatically injecting bibliographic information and links into Roam notes.
 
+- [DevScholar](https://github.com/pallaprolus/dev-scholar)
+  VS Code extension that detects paper references (arXiv, DOI, PubMed, IEEE) in code comments and syncs them two-way with Zotero: push papers cited in code to a linked collection, or import items from Zotero and insert citations. Also shows metadata on hover and previews PDFs inside the editor.
+
 ## Zotero Translators
 
 > Translators determine how Zotero grabs metadata from websites and databases. They are particularly important for Chinese-language sites.


### PR DESCRIPTION
Adds [DevScholar](https://github.com/pallaprolus/dev-scholar) under "Integration with other tools".

DevScholar is a VS Code extension for researchers who write code. It detects paper references in code comments and syncs them two-way with Zotero: papers cited in code are pushed to a linked Zotero collection with duplicate detection, and items from Zotero can be imported and inserted as citations. It also shows metadata on hover, previews PDFs in the editor, and exports BibTeX.

Motivation: the existing entries in this section bridge Zotero to note-taking tools (Obsidian, Notion, Roam, Emacs). DevScholar covers the same gap for source code, where ML and scientific code routinely cites papers in comments. Published on the VS Code Marketplace and Open VSX under the MIT license, with documentation in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)